### PR TITLE
Mangoapp service for the Steam overlays

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,7 @@ cp usr/bin/switch-user-session /usr/bin/switch-user-session
 
 cp usr/lib/systemd/user/gamescope-compositor.service /usr/lib/systemd/user/gamescope-compositor.service
 cp usr/lib/systemd/user/ibusd.service /usr/lib/systemd/user/ibusd.service
+cp usr/lib/systemd/user/mangoapp.service /usr/lib/systemd/user/mangoapp.service
 cp usr/lib/systemd/user/steam-session.target /usr/lib/systemd/user/steam-session.target
 cp usr/lib/systemd/user/steam-ui.service /usr/lib/systemd/user/steam-ui.service
 

--- a/usr/bin/load-steam-session-environment
+++ b/usr/bin/load-steam-session-environment
@@ -33,7 +33,7 @@ systemctl --user set-environment SESSION_RUNDIR="$SESSION_RUNDIR"
 # Enable Mangoapp
 MANGOHUD_CONFIGFILE="$SESSION_RUNDIR/mangohud"
 systemctl --user set-environment STEAM_MANGOAPP_PRESETS_SUPPORTED=1
-systemctl --user set-environment STEAM_USE_MANGOAPP=0
+systemctl --user set-environment STEAM_USE_MANGOAPP=1
 systemctl --user set-environment MANGOHUD_CONFIGFILE="$MANGOHUD_CONFIGFILE"
 echo "no_display" > "$MANGOHUD_CONFIGFILE"
 

--- a/usr/lib/systemd/user/mangoapp.service
+++ b/usr/lib/systemd/user/mangoapp.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Mangoapp overlay
+Before=steam-session.target
+PartOf=steam-session.target
+Requires=gamescope-compositor.service ibusd.service
+After=gamescope-compositor.service ibusd.service
+
+[Service]
+ExecStartPre=/usr/bin/await-gamescope-ready
+ExecStart=/usr/bin/mangoapp
+Type=exec

--- a/usr/lib/systemd/user/steam-ui.service
+++ b/usr/lib/systemd/user/steam-ui.service
@@ -2,11 +2,9 @@
 Description=Steam Big Picture user interface
 Before=steam-session.target
 PartOf=steam-session.target
-Requires=gamescope-compositor.service
-After=gamescope-compositor.service
-Wants=ibusd.service
+Requires=mangoapp.service
+After=mangoapp.service
 
 [Service]
-ExecStartPre=/usr/bin/await-gamescope-ready
 ExecStart=/usr/bin/steam -skipintro -gamepadui -steampal -steamos3 -steamdeck
 Type=exec


### PR DESCRIPTION
Mangoapp is not working well, currently. Whenever the mouse is hidden, Mangoapp is hidden with it (on keyboard or controller input or hide timeout). I do not know the cause of the issue and without very in-depth investigation I doubt I'll ever figure it out.